### PR TITLE
Fix type hint

### DIFF
--- a/src/validator_slop.py
+++ b/src/validator_slop.py
@@ -53,7 +53,7 @@ class SlopPhraseHandler:
         probs_cache: Dict[int, List[int]],
         probs_cache_longrange: Dict[int, bool],
         slop_phrase_prob_adjustments: Dict[str, float],
-        starting_tokens_lookup: Dict[Tuple[int, ...], Set[int]],
+        starting_tokens_lookup: Dict[str, Set[int]],
         adjustment_strength: float,
         slow_debug: bool,
         inference_output: Output | None,


### PR DESCRIPTION
Fix incorrect type hint in `SlopPhraseHandler`

Updated the type hint for `starting_tokens_lookup` from `Dict[Tuple[int, ...], Set[int]]` to `Dict[str, Set[int]]` to match the actual implementation.
